### PR TITLE
Modified YAML prompt

### DIFF
--- a/src/code2verus/agent.py
+++ b/src/code2verus/agent.py
@@ -30,6 +30,8 @@ async def translate_code_to_verus(source_code: str, source_language: str = "dafn
     yaml_prompt = f"""\
         The YAML file contains {source_language} code split into segments. Your job is to translate each of them to its corresponding Verus code while maintaining the YAML structure.
 
+        Make sure the preamble starts with `use vstd::prelude::*;`, immediately followed by a `verus!` block, which starts in the preamble, and closes in the postamble, containing `fn main()`.
+
         IMPORTANT: In your response, include the final YAML file containing Verus code in a code block marked with ```verus. Do not include explanations or summaries in the code block - only the executable Verus code.    
         """
 

--- a/src/code2verus/verification.py
+++ b/src/code2verus/verification.py
@@ -8,13 +8,8 @@ from code2verus.config import cfg
 
 def yaml_to_verus(verus_yaml: str) -> str:     
     try:
-        has_verus = "verus!" in verus_yaml
-        # Remove prelude and main if present so we can ensure they always appear first and last
-        cleaned = verus_yaml.replace("use vstd::prelude::*;", "").replace("fn main() {}", "")
-        as_yaml = yaml.safe_load(cleaned)
-        prefix = f"use vstd::prelude::*;\n{"" if has_verus else "verus! {"}"
-        suffix = f"fn main() {{}}\n{"" if has_verus else "}"}"
-        return  f"{prefix}\n{as_yaml['vc-preamble']}\n{as_yaml['vc-helpers']}\n{as_yaml['vc-spec']}\n{as_yaml['vc-code']}\n{as_yaml['vc-postamble']}\n{suffix}\n"""
+        as_yaml = yaml.safe_load(verus_yaml)
+        return  f"{as_yaml['vc-preamble']}\n{as_yaml['vc-helpers']}\n{as_yaml['vc-spec']}\n{as_yaml['vc-code']}\n{as_yaml['vc-postamble']}\n"""
     except:
         return verus_yaml
 


### PR DESCRIPTION
Instead of compensating for Claude in `verification.py`, this pr pushes more constraints (adding prelude, `verus!` and `main`) into the prompt.

Using this version, Claude successfully translates over 90% of [benchmarks](https://github.com/Beneficial-AI-Foundation/vericoding/tree/main/benchmarks/vericoding_dafny/dafnybench/yaml-depsontop) from YAML-Dafny to YAML-Verus.